### PR TITLE
新增邮件 TLS 验证忽略配置以及剔除启动时展示配置信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ YAPI_MAIL_PORT | number | 邮件服务端口 | 465
 YAPI_MAIL_FROM | string | 发送人邮箱 | foo@163.com
 YAPI_MAIL_AUTH_USER | string | 登录邮件服务的用户名 | bar@163.com
 YAPI_MAIL_AUTH_PASS | string | 登录邮件服务的用户密码 | f00bar
+YAPI_MAIL_TLS_REJECT_UNAUTHORIZED | boolean | 登录邮件服务的验证 | false
 
 #### LDAP 登录配置
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - YAPI_PLUGINS=[]
     depends_on:
       - yapi-mongo
+    links:
+      - yapi-mongo
     restart: unless-stopped
   yapi-mongo:
     image: mongo:latest

--- a/start.js
+++ b/start.js
@@ -110,6 +110,9 @@ const configShape = {
             user: String,
             pass: String,
         },
+        tls: {
+            rejectUnauthorized: Boolean
+        },
     },
     ldapLogin: {
         enable: Boolean,
@@ -231,25 +234,25 @@ class BootstrapServer {
               <script crossorigin="anonymous" src="https://cdn.staticfile.org/fetch/3.0.0/fetch.min.js"></script>
             </head>
             <body>
-              <h1>YApi 正在启动...</h1>
+              <h1>YApi 启动中...</h1>
               <hr />
-              <pre id="data"></pre>
+              <pre id="message"></pre>
               <script>
                 function fetchData() {
-                  var timer = setTimeout(fetchData, 500)
+                  var timer = setTimeout(fetchData, 500);
                   fetch('./logs')
                     .then(function (res) {
-                      return res.json()
+                      return res.json();
                     })
                     .then(function (data) {
-                      document.querySelector('#data').innerHTML = data.join('\\n')
+                      document.querySelector('#message').innerHTML = "配置加载完成，正在加载...";
                     })
                     .catch(function () {
-                      clearTimeout(timer)
-                      setTimeout(function () { location.reload() }, 2000)
+                      clearTimeout(timer);
+                      setTimeout(function () { location.reload() }, 2000);
                     })
                 }
-                fetchData()
+                fetchData();
               </script>
             </body>
           </html>

--- a/start.ts
+++ b/start.ts
@@ -121,6 +121,9 @@ const configShape = {
       user: String,
       pass: String,
     },
+    tls: {
+      rejectUnauthorized: Boolean
+    },
   },
   ldapLogin: {
     enable: Boolean,
@@ -274,25 +277,25 @@ class BootstrapServer {
               <script crossorigin="anonymous" src="https://cdn.staticfile.org/fetch/3.0.0/fetch.min.js"></script>
             </head>
             <body>
-              <h1>YApi 正在启动...</h1>
+              <h1>YApi 启动中...</h1>
               <hr />
-              <pre id="data"></pre>
+              <pre id="message"></pre>
               <script>
                 function fetchData() {
-                  var timer = setTimeout(fetchData, 500)
+                  var timer = setTimeout(fetchData, 500);
                   fetch('./logs')
                     .then(function (res) {
-                      return res.json()
+                      return res.json();
                     })
                     .then(function (data) {
-                      document.querySelector('#data').innerHTML = data.join('\\n')
+                      document.querySelector('#message').innerHTML = "配置加载完成，正在加载...";
                     })
                     .catch(function () {
-                      clearTimeout(timer)
-                      setTimeout(function () { location.reload() }, 2000)
+                      clearTimeout(timer);
+                      setTimeout(function () { location.reload() }, 2000);
                     })
                 }
-                fetchData()
+                fetchData();
               </script>
             </body>
           </html>


### PR DESCRIPTION
1. 剔除启动时展示配置信息
2. 增加邮箱 TLS 验证配置
3. web 中 docker-compose 中添加网络 link（docker 19.03.5 测试时没有添加则网络不通）

为什么需要【剔除启动时展示配置信息】会把相关的配置暴露导致不安全，如密码等。
