### PR TITLE
支持docker-compose直接挂载插件包

### DIFF
--- a/start.ts
+++ b/start.ts
@@ -374,11 +374,15 @@ class Main {
   async installPluginsIfNeeded() {
     if (Array.isArray(this.config.plugins) && this.config.plugins.length > 0) {
       const packages = this.config.plugins
-        .map((plugin) => `yapi-plugin-${plugin.name}`)
-        .filter(
-          (packageName) =>
-            !fs.existsSync(`/yapi/vendors/node_modules/${packageName}`),
-        )
+        .map((plugin) =>{ 
+          let localPkg=`/yapi/vendors/node_modules/yapi-plugin-${plugin.name}`;
+          if(fs.existsSync(localPkg)){
+            this.log('加载本地插件：'+localPkg)
+            return `file:${localPkg}`
+          }else{
+            return `yapi-plugin-${plugin.name}`
+          }
+        })
         .join(' ')
       if (packages.length > 0) {
         await Helper.exec(


### PR DESCRIPTION
当前插件必须上架到yarn商店才能安装，yarn本身是支持 `yarn add file:<localpath> `  安装的, 增加判断用于兼容

```
volumes: 
      - /home/xxxxxx/yapi-plugin-hello-master:/yapi/vendors/node_modules/yapi-plugin-hello
```