### PR TITLE
fix: 修复侧边栏 menu 闪烁问题

### DIFF
--- a/prepare.ts
+++ b/prepare.ts
@@ -96,6 +96,16 @@ async function prepare(rootDir: string) {
     '',
   )
   await fs.writeFile(ykitConfigFile, ykitConfigContent)
+
+  // 修复侧边栏 menu 闪烁问题
+  const commonCssPath = join(rootDir, './client/styles/common.scss')
+  let commonCssPathContent = await fs.readFile(commonCssPath, 'utf8')
+  commonCssPathContent =
+    commonCssPathContent +
+    `.ant-menu-inline .ant-menu-item,.ant-menu-inline .ant-menu-submenu-title {
+    width: 100%;
+  }`
+  await fs.writeFile(commonCssPath, commonCssPathContent)
 }
 
 prepare(process.argv[2])

--- a/prepare.ts
+++ b/prepare.ts
@@ -98,14 +98,14 @@ async function prepare(rootDir: string) {
   await fs.writeFile(ykitConfigFile, ykitConfigContent)
 
   // 修复侧边栏 menu 闪烁问题
-  const commonCssPath = join(rootDir, './client/styles/common.scss')
-  let commonCssPathContent = await fs.readFile(commonCssPath, 'utf8')
-  commonCssPathContent =
-    commonCssPathContent +
+  const commonCssFile = join(rootDir, './client/styles/common.scss')
+  let commonCssContent = await fs.readFile(commonCssFile, 'utf8')
+  commonCssContent =
+    commonCssContent +
     `.ant-menu-inline .ant-menu-item,.ant-menu-inline .ant-menu-submenu-title {
     width: 100%;
   }`
-  await fs.writeFile(commonCssPath, commonCssPathContent)
+  await fs.writeFile(commonCssFile, commonCssContent)
 }
 
 prepare(process.argv[2])


### PR DESCRIPTION
# 问题

侧边栏选中后的蓝色标记变短，并且鼠标移入 hover 时会出现整体闪烁

错误情况：
![image](https://user-images.githubusercontent.com/31910599/141225458-ab3411dd-62d4-4097-8d03-11b3ba157270.png)

正确情况：
![image](https://user-images.githubusercontent.com/31910599/141225513-ea604fba-f85b-4172-a2d5-8dffdd389a78.png)
